### PR TITLE
Prevent default actions on toolbar buttons

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -63,6 +63,10 @@ widgets.define('text-editor', (options) => {
 
         widgets.dispatch(textarea, 'input')
         widgets.dispatch(textarea, 'change')
+
+        e.stopImmediatePropagation()
+        e.preventDefault()
+        false
       }))
     })
 


### PR DESCRIPTION
Otherwise clicking a toolbar button could submit a form wrapping the
editor